### PR TITLE
Update META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -7,6 +7,6 @@
     "provides" : {
         "UNIX::Privileges" : "lib/UNIX/Privileges.pm6"
     },
-    "source-url" : "git://github.com/carbin/p6-unix-privileges.git"
+    "source-url" : "git://github.com/nbrown/p6-unix-privileges.git"
 }
 


### PR DESCRIPTION
Hi,
it appears that you changed your GH username and didn't change the META.info, this should make the module installable again.

I've already fixed it in the modules list.

Thanks,